### PR TITLE
Fix empty response handling

### DIFF
--- a/examples/get-leaf-info.py
+++ b/examples/get-leaf-info.py
@@ -79,12 +79,15 @@ async def main():
 
             print("get_latest_battery_status from servers")
             leaf_info = await leaf.get_latest_battery_status()
-            start_date = leaf_info.answer["BatteryStatusRecords"]["OperationDateAndTime"]
-            print("start_date=", start_date)
-            print_info(leaf_info)
+            if leaf_info:
+                start_date = leaf_info.answer["BatteryStatusRecords"]["OperationDateAndTime"]
+                print("start_date=", start_date)
+                print_info(leaf_info)
 
             hvac_status = await leaf.get_latest_hvac_status()
-            print(f"hvac_status: is_running={hvac_status.is_hvac_running}, duration={hvac_status.ac_duration}, start_stop_time={hvac_status.ac_start_stop_date_and_time}")
+
+            if hvac_status:
+                print(f"hvac_status: is_running={hvac_status.is_hvac_running}, duration={hvac_status.ac_duration}, start_stop_time={hvac_status.ac_start_stop_date_and_time}")
 
             # Give the nissan servers a bit of a delay so that we don't get stale data
             await asyncio.sleep(1)
@@ -94,9 +97,11 @@ async def main():
             await update_battery_status(leaf, sleepsecs)
 
             latest_leaf_info = await leaf.get_latest_battery_status()
-            latest_date = latest_leaf_info.answer["BatteryStatusRecords"]["OperationDateAndTime"]
-            print("latest_date=", latest_date)
-            print_info(latest_leaf_info)
+
+            if latest_leaf_info:
+                latest_date = latest_leaf_info.answer["BatteryStatusRecords"]["OperationDateAndTime"]
+                print("latest_date=", latest_date)
+                print_info(latest_leaf_info)
 
         except pycarwings3.CarwingsError as e:
             raise e

--- a/pycarwings3/pycarwings3.py
+++ b/pycarwings3/pycarwings3.py
@@ -78,6 +78,7 @@ from .responses import (
     CarwingsElectricRateSimulationResponse,
     CarwingsClimateControlScheduleResponse,
     CarwingsMyCarFinderResponse,
+    NoDataError,
 )
 import base64
 from Crypto.Cipher import Blowfish
@@ -99,7 +100,6 @@ def _PKCS5Padding(string):
 
 class CarwingsError(Exception):
     pass
-
 
 class Session(object):
     """Maintains a connection to CARWINGS, refreshing it when needed"""
@@ -497,8 +497,8 @@ class Leaf:
             if "BatteryStatusRecords" in response:
                 try:
                     return CarwingsLatestBatteryStatusResponse(response)
-                except ValueError as error:
-                    log.warning(error.message)
+                except NoDataError as error:
+                    log.warning(error)
             else:
                 log.warning("no battery status record returned by server")
 

--- a/pycarwings3/pycarwings3.py
+++ b/pycarwings3/pycarwings3.py
@@ -111,13 +111,13 @@ class Session(object):
         self.logged_in = False
         self.custom_sessionid = None
         self.base_url = base_url
-        if (session):
+        if session is not None:
             self._shared_session = True
             self.session = session
         else:
             self._shared_session = False
             self.session = ClientSession(
-                timeout=ClientTimeout(300, connect=5)
+                timeout=ClientTimeout(connect=120, total=600)
             )
 
         self._semaphore = Semaphore(1)

--- a/pycarwings3/responses.py
+++ b/pycarwings3/responses.py
@@ -20,6 +20,8 @@ import pycarwings3
 
 log = logging.getLogger(__name__)
 
+class NoDataError(Exception):
+    pass
 
 def _time_remaining(t):
     minutes = float(0)
@@ -680,8 +682,15 @@ class CarwingsLatestBatteryStatusResponse(CarwingsResponse):
             "TargetDate": "2016/02/19 17:12"
           }
         }
+
+        # empty BatteryStatusRecords.BatteryStatus
+        {"status":200,"BatteryStatusRecords":[]}
+
     """
     def __init__(self, status):
+        if isinstance(status["BatteryStatusRecords"], list) and status["BatteryStatusRecords"] == []:
+            raise NoDataError("got an empty BatteryStatusRecords")
+        
         CarwingsResponse.__init__(self, status["BatteryStatusRecords"])
         self.answer = status
 
@@ -691,7 +700,7 @@ class CarwingsLatestBatteryStatusResponse(CarwingsResponse):
 
         # check if the BatteryStatusRecords.BatteryStatus is an empty array (insted of an object)
         if isinstance(bs, list) and bs == []:
-            raise ValueError("BatteryStatusRecords.BatteryStatus is an empty array")
+            raise NoDataError("BatteryStatusRecords.BatteryStatus is an empty array")
             
         self.battery_capacity = bs["BatteryCapacity"]
         self.battery_remaining_amount = bs["BatteryRemainingAmount"]

--- a/tests/test_pycarwings3.py
+++ b/tests/test_pycarwings3.py
@@ -8,7 +8,8 @@ import pytz
 import pytest
 from pycarwings3.responses import (
     CarwingsLatestBatteryStatusResponse,
-    CarwingsLatestClimateControlStatusResponse
+    CarwingsLatestClimateControlStatusResponse,
+    NoDataError
 )
 
 pytest_plugins = ('pytest_asyncio',)
@@ -372,7 +373,19 @@ def test_get_latest_battery_status_with_empty_status():
         }
 """
     response = json.loads(batteryresponse)
-    with pytest.raises(ValueError):
+    with pytest.raises(NoDataError):
       CarwingsLatestBatteryStatusResponse(response)
       pytest.fail('Should fail with ValueError')
+  
+def test_get_latest_battery_status_with_empty_status_records():
+    batteryresponse = """
+        {
+            "status":200,
+            "BatteryStatusRecords": []
+        }
+"""
+    response = json.loads(batteryresponse)
+    with pytest.raises(NoDataError):
+      CarwingsLatestBatteryStatusResponse(response)
+      pytest.fail('Should fail with NoDataError')
   


### PR DESCRIPTION
Do not fail when getting an empty response with the error:

```
TypeError: list indices must be integers or slices, not str
```

Relates https://github.com/remuslazar/homeassistant-carwings/issues/45