### PR TITLE
fix: UserAgent header will result in an error: 404 invalid params

### DIFF
--- a/pycarwings3/pycarwings3.py
+++ b/pycarwings3/pycarwings3.py
@@ -184,7 +184,7 @@ class Session(object):
 
             # Nissan servers sometimes do not respond.
             # Connections seem OK, but reads are slow and may not be successful
-            async with self.session.post(url, data=params) as response:
+            async with self.session.post(url, data=params, headers=[]) as response:
                 log.debug(
                     "Response HTTP Status Code: {status_code}".format(
                         status_code=response.status


### PR DESCRIPTION
The homeassistant integration https://github.com/remuslazar/homeassistant-carwings stopped working recently. The pycarwings3 lib is returning an error `404 INVALID PARAMS`. I traced it down to the User Agent header that is provided by home assistants aio_http client. 

The problem is, that home assistant provides no method to override the headers. Their solution is to override the headers in the request method. For the custom component this request method is inside this library. As the carwings code does not need any headers, I just set them to an empty array. I'm not sure if this is the best way to handle this issue.

Please see my comment here and the issue for all details: https://github.com/remuslazar/homeassistant-carwings/issues/79#issuecomment-2596827368