### PR TITLE
Update pycarwings3.py re. the parameter initial_app_str

### DIFF
--- a/pycarwings3/pycarwings3.py
+++ b/pycarwings3/pycarwings3.py
@@ -147,11 +147,11 @@ class Session(object):
         return ret
 
     async def _request(self, endpoint, params):
+        params["initial_app_str"] = "9s5rfKVuMrT03RtzajWNcA"
         if self.custom_sessionid:
             params["custom_sessionid"] = self.custom_sessionid
         else:
             params["custom_sessionid"] = ""
-            params["initial_app_str"] = "9s5rfKVuMrT03RtzajWNcA"
 
         url = self.base_url + endpoint
 


### PR DESCRIPTION
Der Parameter initial_app_str muss immer belegt werden, nicht nur bei fehlender custom_sessionid. 
Ansonsten sind keine neuen Daten auf dem Server und BatteryStatusCheckResultRequest anwortet stets mit dem responseFlag 0. 
Siehe auch PR https://github.com/openWB/core/pull/1682#issuecomment-2693937995
Nach der Änderung entspricht pycarwings3 an dieser Code-Stelle wieder dem Code in pycarwings2.